### PR TITLE
Adds a cron job to this server to hit the 360Giving site every 15mins

### DIFF
--- a/salt/dkan-script.sls
+++ b/salt/dkan-script.sls
@@ -45,3 +45,10 @@ cd /home/threesixty/data-conversion/scripts/ && ./generate_report.sh > /home/thr
     - user: threesixty
     - minute: 3
     - hour: 1
+
+#Set a cron job to run every two hours to refresh the data at 360 Giving website
+wget -O - http://threesixtygiving.org/get-involved/data/ >/dev/null 2>&1
+  cron.present:
+    - identifier: 360DKANCRON
+    - user: threesixty
+    - minute: '*/15'


### PR DESCRIPTION
To refresh the data at 360, the http://threesixtygiving.org/get-involved/data/ needs to be hit regularly.
(It has a 2 hour cash on it)
So this should hit it every 15 mins and write the result to nothing