### PR TITLE
[planio#5476] Patched icinga2 for Ubuntu 16.04.

### DIFF
--- a/salt/icinga/check_memory_new_free_output.patch
+++ b/salt/icinga/check_memory_new_free_output.patch
@@ -1,0 +1,38 @@
+--- check_memory.orig	2015-08-18 18:17:21.000000000 +0200
++++ check_memory	2015-11-29 15:14:07.493644046 +0100
+@@ -104,12 +104,23 @@
+   or $np->nagios_exit('CRITICAL', "Could not run $FREECMD");
+ 
+ warn("Output from $FREECMD:\n") if ($verbose > 1);
+-my ($used, $free);
++my $new_format = 0;
++my ($total, $used, $free);
+ while (<RESULT>) {
+   warn("  $_") if ($verbose > 1);
+-  next unless (m#^\-/\+\ buffers/cache:\s*(\d+)\s+(\d+)#);
+-  $used = $1;
+-  $free = $2;
++  # New `free` output from procps doesn't provide "buffers/cache" anymore, but
++  # provides a better estimate of available memory ("available" column).
++  $new_format = 1 if m{^\s+total\s+used\s+free\s+shared\s+buff/cache\s+available$};
++
++  if ($new_format and /^Mem:\s+(\d+)\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+)$/) {
++    $total = $1;
++    $free = $2; # available column
++    $used = $total - $free; # used is everything which is not available
++  } elsif (m#^\-/\+\ buffers/cache:\s*(\d+)\s+(\d+)#) {
++    $used = $1;
++    $free = $2;
++    $total = $used + $free;
++  }
+ }
+ 
+ close(RESULT);
+@@ -117,7 +128,6 @@
+ 
+ $np->nagios_exit('CRITICAL', "Unable to interpret $FREECMD output") if (!defined($free));
+ 
+-my $total = $used + $free;
+ if (defined($warning) && $warning =~ /^\d+%$/) {
+   if ($warning) {
+     $warning =~ s/%//;

--- a/salt/icinga2-base.sls
+++ b/salt/icinga2-base.sls
@@ -34,3 +34,11 @@ icinga2:
     - watch_in:
       - service: icinga2
 {% endfor %}
+
+# bugfix: planio#5476
+{% if grains['osrelease'] == '16.04' %}
+/usr/lib/nagios/plugins/check_memory:
+  file.patch:
+    - source: salt://icinga/check_memory_new_free_output.patch
+    - hash: md5=d7f464052b3114f90948c0488df30b25
+{% endif %}


### PR DESCRIPTION
Actually the patch is backward compatible with 14.04 but from an abundance of caution the salt state checks the grain and only applies on 16.04 ... also a patched 14.04 check_memory file is different to a patched 16.04 check_memory file, so just don't do this on a 14.04 system.