### PR TITLE
[planio#5120] Add 'coop' username on backups server.

### DIFF
--- a/salt/backups.sls
+++ b/salt/backups.sls
@@ -3,6 +3,9 @@
 {% set user = 'automated' %}
 {{ createuser(user) }}
 
+{% set user = 'coop' %}
+{{ createuser(user) }}
+
 acl:
   pkg.installed
 


### PR DESCRIPTION
The additions in createuser() in lib.sls allow us to set up ssh authorized_keys on a per-username basis.  

The change in backups.sls uses this to set up a 'coop' username on the backups server for additional people (Tim and Rob in the first instance) to push stuff onto 'backups'.  

We're also going to use this exact same setup for the exact same people to ssh-tunnel via dev3 to get to the Switchboard of Miami database (for Open Referral). 

See also the common-pillar.sls private pillar.
