### PR TITLE
Fix for salt-2017.07.1: specify ssh fingerprint type.

### DIFF
--- a/salt/lib.sls
+++ b/salt/lib.sls
@@ -283,4 +283,5 @@ extra_reload_{{ servername }}:
     - user: {{ user }}
     - enc: rsa
     - fingerprint: 77:d1:54:d7:33:7e:38:43:40:70:ca:2d:3a:24:05:22
+    - fingerprint_hash_type: md5
 {% endmacro %}


### PR DESCRIPTION
Salt 2017.07.0 changed the default hash format from md5 to sha256, but their handling of openssh's sha256 fingerprint is apparently broken. Work round it by explicitly saying that the obviously md5-formatted fingerprint (which still works perfectly well in openssh-7.4p1) is md5-formatted. (And if I can see the difference between md5 and sha256, why can't salt intuit it?)

Upstream refs: 
https://github.com/saltstack/salt/issues/41653
https://github.com/saltstack/salt/issues/40878
https://github.com/saltstack/salt/issues/40005
