### PR TITLE
Add kingfisher archive user config

### DIFF
--- a/ocdskingfisherarchive/archive.sudoers
+++ b/ocdskingfisherarchive/archive.sudoers
@@ -1,0 +1,1 @@
+archive ALL = (ocdskfs) rm -rf /home/ocdskfs/scrapyd/data/*

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -59,9 +59,6 @@ base:
   'ocdskingfisher-dev':
      - ocdskingfisher_dev_pillar
 
-  'ocds-kingfisher-archive':
-     - ocdskingfisher_archive_pillar
-
   'ocds-redash*':
      - private.ocds_redash_pillar
 

--- a/salt/ocdskingfisherarchive.sls
+++ b/salt/ocdskingfisherarchive.sls
@@ -1,4 +1,10 @@
-{% from 'lib.sls' import createuser %}
+{% from 'lib.sls' import createuser, private_keys %}
 
 {% set user = 'archive' %}
 {{ createuser(user) }}
+{{ private_keys(user) }}
+
+/etc/sudoers.d/archive:
+  file.managed:
+    - source: salt://ocdskingfisherarchive/archive.sudoers
+    - makedirs: True


### PR DESCRIPTION
@odscjames So, I've been trying to work out a good way of allowing the servers to what they need and nothing more. I think what I've proposed below is sane. Can you check that assumption? 

You can ignore the private keys and pillar stuff, that's gotten pulled into this PR because I forgot to commit it when I was working earlier - sorry! It's just the sudoers stuff that matter here. You can assume that the archive user can log into itself on either server (as it now can)