### PR TITLE
uwsgi: Set post-buffering.

### DIFF
--- a/salt/uwsgi/cove.ini
+++ b/salt/uwsgi/cove.ini
@@ -42,6 +42,9 @@ harakiri = 60
 {% endif %}
 # If memory usage of a worker > 250MB at the *end* of a request, then reload it
 reload-on-as = 250
+# handle slow POST requests, and avoid socket problems with harakiri mode
+post-buffering = true
+post-buffering-bufsize = 65536
 
 # ==== Stats ====
 {% if port == 3031 %}


### PR DESCRIPTION
As reported by Steven, a slow or incompletely processed or terminated
POST into Cove (or any other uwsgi app) can cause a worker's socket to
be removed, and subsequent unrelated requests will fail. POST buffering
seems to be uwsgi's mechanism for preventing this. For details see
https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html

(But we shouldn't merge this to literally all our uwsgi things until we've
assured ourselves that it doesn't cause problems.)
